### PR TITLE
Fix naming error with exported files

### DIFF
--- a/diagram_reader.py
+++ b/diagram_reader.py
@@ -18,6 +18,15 @@ PERSON_HEIGHT = 50
 DIAGRAMS_DIR = "save-files";
 PHOTOS_DIR_NAME = "photos";
 
+def removeExtension(fileName, extension):
+    """Remove the extension from the given file name."""
+
+    if fileName.endswith(extension):
+        return fileName[:-len(extension)]
+
+    # Default case.
+    return fileName
+
 def getDiagramName():
     """Get the diagram name."""
 
@@ -367,7 +376,8 @@ def export_to_xml(name, persons, relationships, diagramProperties):
     # Make file name.
     now = datetime.datetime.now()
     timestamp = now.strftime("%Y%m%d-%H%M%S")
-    outputFileName = name + "-" + timestamp + ".xml"
+    basename = removeExtension(name, ".xml")
+    outputFileName = basename + "-" + timestamp + ".xml"
 
     # Write the XML file.
     dest = os.path.join(getExportedFilesDir(), outputFileName);

--- a/diagram_reader.py
+++ b/diagram_reader.py
@@ -317,7 +317,8 @@ def export_to_csv(name, persons, relationships):
     # Make file name.
     now = datetime.datetime.now()
     timestamp = now.strftime("%Y%m%d-%H%M%S")
-    outputFileName = name + "-" + timestamp + ".csv";
+    basename = removeExtension(name, ".xml")
+    outputFileName = basename + "-" + timestamp + ".csv";
 
     # Export.
     try:

--- a/org_chart_maker/static/help.html
+++ b/org_chart_maker/static/help.html
@@ -118,6 +118,12 @@ This will download a CSV file containing all the people in the diagram.</p>
 
 <p>To export the diagram as a XML file, select "Export --> XML" from the top menu.</p>
 
+<p>Exported CSV and XML files have a timestamp in the filename. For example, for a diagram called "department-test", the exported CSV file could be called:</p>
+
+<p><pre>    department-test-20230830-045301.csv</pre></p>
+
+<p>Here "20230830-045301" is the timestamp for 30 August 2023 at 4:53:01 AM.</p>
+
 <p><b>Editing Preferences</b></p>
 
 <p>To change your preferences, click "Preferences" (Options --> Preferences) in the top menu.</p>


### PR DESCRIPTION
For instance, the exported XML file would be called:

```department-test.xml-20230830-025826.xml```

Note the two ".xml" instances. Now it is instead called:

```department-test-20230830-030606.xml```

I.e. there is only one ".xml" in the file name now.