### PR TITLE
Prevent marquee select rectangle displaying when dragging items

### DIFF
--- a/org_chart_maker/static/help.html
+++ b/org_chart_maker/static/help.html
@@ -150,6 +150,8 @@ it, then click the "Delete" button on the left of the page.</p>
 
 <p>Currently only the last selected item is deleted when you click the "Delete" button.</p>
 
+<p>NOTE: There is currently an issue where the rectangle shows up briefly when you click+drag an item on the diagram.
+
 
 <p><b>Editing Diagram Properties</b></p>
 

--- a/org_chart_maker/templates/diagram_editor/index.html
+++ b/org_chart_maker/templates/diagram_editor/index.html
@@ -1502,6 +1502,7 @@ function updateDiagramBasedOnProperties() {
       layer.add (marqueeSelectRect);
 
       stage.on('mousedown', function() {
+        console.log("Stage mousedown event.");
         if (diagramMode == DEFAULT && itemWasClicked == false) {
           // Marquee select...
           doingRectangleSelect = true;
@@ -1626,6 +1627,14 @@ function updateDiagramBasedOnProperties() {
 
         // Handle dragging other selected persons.
         group.on('dragmove', function (e) {
+          // Cancel marquee select.
+          // TODO: This doesn't work, either...
+          // The event is often not triggered!
+          doingRectangleSelect = false;
+          marqueeSelectRect.visible(false);
+          console.log("Group drag move event.");
+
+          // Drag other selected persons.
           for (var index in persons) {
             var person = persons[index];
             if (person.selected && person != selectedPerson) {
@@ -1720,10 +1729,15 @@ function updateDiagramBasedOnProperties() {
         });
 
         group.on('mousedown', function (e) {
+          // console.log("Group mousedown event.");
           itemWasClicked = true; // Disable marquee select...
           if (diagramMode == ADD_RELATIONSHIP) {
+            console.log("Group mousedown event.");
             newRelationshipParent = person;
             drawingArrow = true;
+          }
+          else {
+            console.log("Group mousedown event.");
           }
         });
 

--- a/org_chart_maker/templates/diagram_editor/index.html
+++ b/org_chart_maker/templates/diagram_editor/index.html
@@ -1502,7 +1502,7 @@ function updateDiagramBasedOnProperties() {
       layer.add (marqueeSelectRect);
 
       stage.on('mousedown', function() {
-        console.log("Stage mousedown event.");
+        // console.log("Stage mousedown event.");
         if (diagramMode == DEFAULT && itemWasClicked == false) {
           // Marquee select...
           doingRectangleSelect = true;
@@ -1628,13 +1628,12 @@ function updateDiagramBasedOnProperties() {
         // Handle dragging other selected persons.
         group.on('dragmove', function (e) {
           // Cancel marquee select.
-          // TODO: This doesn't work, either...
-          // The event is often not triggered!
+          // NOTE: The event is often not triggered!
           doingRectangleSelect = false;
           marqueeSelectRect.visible(false);
-          console.log("Group drag move event.");
+          // console.log("Group drag move event.");
 
-          // Drag other selected persons.
+          // Drag other selected items.
           for (var index in persons) {
             var person = persons[index];
             if (person.selected && person != selectedPerson) {
@@ -1732,12 +1731,8 @@ function updateDiagramBasedOnProperties() {
           // console.log("Group mousedown event.");
           itemWasClicked = true; // Disable marquee select...
           if (diagramMode == ADD_RELATIONSHIP) {
-            console.log("Group mousedown event.");
             newRelationshipParent = person;
             drawingArrow = true;
-          }
-          else {
-            console.log("Group mousedown event.");
           }
         });
 


### PR DESCRIPTION
Prevent the green marquee select rectangle displaying when clicking+dragging items.

Fixes #103.